### PR TITLE
Install standard ci.yaml for r2u use

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,43 @@
+# Run CI for R using https://eddelbuettel.github.io/r-ci/
+
+name: ci
+
+on:
+  push:
+  pull_request:
+
+env:
+  _R_CHECK_FORCE_SUGGESTS_: "false"
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        include:
+          #- {os: macOS-latest}
+          - {os: ubuntu-latest}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: eddelbuettel/github-actions/r-ci-setup@master
+
+      - name: Bootstrap
+        run: ./run.sh bootstrap
+
+      #- name: Dependencies
+      #  run: ./run.sh install_deps
+
+      - name: All Dependencies
+        run: ./run.sh install_all
+     
+      - name: Test
+        run: ./run.sh run_tests
+
+      #- name: Coverage
+      #  if: ${{ matrix.os == 'ubuntu-latest' }}
+      #  run: ./run.sh coverage


### PR DESCRIPTION
As discussed [over at the r2u repo yesterday](https://github.com/eddelbuettel/r2u/issues/60) this PR adds my standard `ci.yaml`.  I added an extra paragraph with 'install_all' to explicitly install suggested dependencies as well as actual dependencies (I usually stick with just depends in most cases, one larger package at work also installs all suggests for maximum test coverage).  Additional blocks or commands can be added, if needed, as usual via shell or Rscript snippet.  

In my action, the deploy step failed but that was expected as I do not have your tokens.  I think you can tune in the opening paragraph when these actions are triggered to exclude forks and/or skip the corresponding steps if the variables are empty.

As you see, I also skip tests on macOS "because life is too short".  For most things this should just work: the underlying script happily installs R for macOS and packages resolve well (and fast) too as binaries "in most cases".  But because I don't work on a mac myself I never quite _au courant_ about what is happening and prefer to just skip these tests rather than chase occassional one-offs.  Your mileage may differ, it is easy to turn this on.  Similarly, I usually run Windows off a different yaml script when I have to.

As you can, this did what it set out to do, and quickly, and that usually works for me.  

![image](https://github.com/ESHackathon/CiteSource/assets/673121/21e82b7c-e843-4375-bee0-13375e1cb0a0)
