### PR TITLE
Add DESCRIPTION to Shiny app dir so rsconnect includes CiteSource

### DIFF
--- a/inst/shiny-app/CiteSource/DESCRIPTION
+++ b/inst/shiny-app/CiteSource/DESCRIPTION
@@ -1,0 +1,8 @@
+Package: CiteSourceApp
+Title: CiteSource Shiny Application
+Version: 0.2.0
+Description: Interactive Shiny application for CiteSource.
+Imports:
+  CiteSource
+Remotes:
+  ESHackathon/CiteSource@dev


### PR DESCRIPTION
rsconnect uses Remotes: field to know CiteSource comes from GitHub. Without this, CiteSource was missing from the deployment manifest and shinyapps.io never installed it.