### PR TITLE
Install CiteSource via pak in setup step so rsconnect detects it

### DIFF
--- a/.github/workflows/document-and-deploy.yml
+++ b/.github/workflows/document-and-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up R Dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: devtools, roxygen2, remotes, rsconnect, pkgdown
+          extra-packages: devtools, roxygen2, remotes, rsconnect, pkgdown, ESHackathon/CiteSource@dev
 
       - name: Create documentation
         run: |
@@ -52,7 +52,6 @@ jobs:
           RENV_CONFIG_SNAPSHOT_VALIDATE: "false"
         run: |
           R -e "
-            remotes::install_github('ESHackathon/CiteSource', force = TRUE);
             rsconnect::setAccountInfo(name=${{secrets.SHINY_LUKAS_ACCOUNT}}, token=${{secrets.SHINY_LUKAS_TOKEN}}, secret=${{secrets.SHINY_LUKAS_SECRET}});
             rsconnect::deployApp(
               appName = 'CiteSource_latest',
@@ -66,7 +65,6 @@ jobs:
           RENV_CONFIG_SNAPSHOT_VALIDATE: "false"
         run: |
           R -e "
-            remotes::install_github('ESHackathon/CiteSource', force = TRUE);
             rsconnect::setAccountInfo(name=${{secrets.SHINY_LUKAS_ACCOUNT}}, token=${{secrets.SHINY_LUKAS_TOKEN}}, secret=${{secrets.SHINY_LUKAS_SECRET}});
             rsconnect::deployApp(
               appName = 'CiteSource',


### PR DESCRIPTION
remotes::install_github installs into a separate library that renv/pak (used by rsconnect for dependency detection) cannot see. Installing via extra-packages puts CiteSource in the same library so rsconnect includes it in the deployment manifest.