### PR TITLE
Use renv::install for CiteSource 

### DIFF
--- a/.github/workflows/document-and-deploy.yml
+++ b/.github/workflows/document-and-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up R Dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: devtools, roxygen2, remotes, rsconnect, pkgdown, ESHackathon/CiteSource@dev
+          extra-packages: devtools, roxygen2, remotes, rsconnect, pkgdown
 
       - name: Create documentation
         run: |
@@ -52,6 +52,7 @@ jobs:
           RENV_CONFIG_SNAPSHOT_VALIDATE: "false"
         run: |
           R -e "
+            renv::install('ESHackathon/CiteSource@dev');
             rsconnect::setAccountInfo(name=${{secrets.SHINY_LUKAS_ACCOUNT}}, token=${{secrets.SHINY_LUKAS_TOKEN}}, secret=${{secrets.SHINY_LUKAS_SECRET}});
             rsconnect::deployApp(
               appName = 'CiteSource_latest',
@@ -65,6 +66,7 @@ jobs:
           RENV_CONFIG_SNAPSHOT_VALIDATE: "false"
         run: |
           R -e "
+            renv::install('ESHackathon/CiteSource');
             rsconnect::setAccountInfo(name=${{secrets.SHINY_LUKAS_ACCOUNT}}, token=${{secrets.SHINY_LUKAS_TOKEN}}, secret=${{secrets.SHINY_LUKAS_SECRET}});
             rsconnect::deployApp(
               appName = 'CiteSource',

--- a/inst/shiny-app/CiteSource/DESCRIPTION
+++ b/inst/shiny-app/CiteSource/DESCRIPTION
@@ -1,8 +1,0 @@
-Package: CiteSourceApp
-Title: CiteSource Shiny Application
-Version: 0.2.0
-Description: Interactive Shiny application for CiteSource.
-Imports:
-  CiteSource
-Remotes:
-  ESHackathon/CiteSource@dev


### PR DESCRIPTION
Use renv::install for CiteSource so rsconnect detects it as GitHub source

 (used by extra-packages) marks transitive deps as 'deps' source type, which shinyapps.io rejects. renv::install installs into renv's own library with proper GitHub source metadata that rsconnect and shinyapps.io both understand.