### PR TITLE
CiteSource 0.2.1 — CRAN resubmission + incremental/deferred dedup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CiteSource
 Title: Data-Driven Search Strategy Development and Evidence Synthesis Reporting
 Version: 0.2.1
-Date: 2026-06-01
+Date: 2026-06-08
 Authors@R: c(
     person("Trevor", "Riley", , "tnriley@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6834-9802")),
@@ -22,11 +22,12 @@ Authors@R: c(
     person("Kaitlyn", "Hair", role = "cph", comment = "Author of included ASySD deduplication code"),
     person("CAMARADES Group", role = "cph", comment = "Authors of ASySD (github.com/camaradesuk/ASySD)")
   )
-Description: Tools for data-driven search strategy development and evidence
-             synthesis reporting. Researchers can deduplicate references while
-             maintaining customizable metadata, analyze results using
-             plots and tables, and import or export data in 'RIS' and 'CSV' formats.
-             An interactive 'shiny' application is included for exploratory use.
+Description: Deduplicates bibliographic citations from multiple sources while
+             preserving customizable metadata, supporting data-driven search
+             strategy development and evidence synthesis reporting. Search
+             results can be analyzed using plots and tables, and imported or
+             exported in 'RIS' and 'CSV' formats. An interactive 'shiny'
+             application is included for exploratory use.
 License: GPL (>= 3)
 URL: https://eshackathon.github.io/CiteSource/
 BugReports: https://github.com/ESHackathon/CiteSource/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,6 @@ Suggests:
     htmltools,
     jsonlite,
     knitr,
-    networkD3,
     plotly,
     progressr,
     rmarkdown,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,43 +1,54 @@
-## Submission
+## Resubmission
 
-This is a minor feature update (0.2.0 -> 0.2.1).
+This is a resubmission of a new package (not yet on CRAN). It addresses all
+points raised in the previous review:
 
-New in this version:
+* **Title / Description formatting.** The `Title` no longer begins with
+  "An R Package for", and the `Description` no longer begins with "Tools for".
+  The `Description` now opens with an active verb describing what the package
+  does. All software/package names in the `Title` and `Description`
+  (`'shiny'`, `'RIS'`, `'CSV'`) are written in single quotes.
 
-* `dedup_citations_add_sources()` adds new citations to a previously
-  deduplicated set and deduplicates across both, preserving prior merge
-  decisions and record provenance (incremental deduplication).
-* `export_dedup_candidates()` / `reimport_dedup_candidates()`, and a
-  `manual_dedup_complete` flag in `export_csv()`, support performing automatic
-  deduplication now and completing manual review later.
-* `reimport_csv()` now reads all columns as character so a re-imported set can
-  re-enter the manual-merge / incremental-deduplication functions without
-  column-type clashes.
-* Documentation and bundled 'shiny' application updates.
+* **Missing `\value` tags.** `@return` documentation was added to all flagged
+  functions (`export_bib`, `export_ris`, `plot_contributions`,
+  `plot_source_overlap_upset`, `reimport_ris`) and the `.Rd` files were
+  regenerated. Functions called for their side effects use the phrasing
+  "No return value, called for side effects." and state what file is written;
+  functions that return objects describe the class and meaning of the output.
+  All exported functions now carry a `\value` tag.
+
+* **Writing to the home filespace.** Default `filename` values were removed
+  from `export_csv()`, `export_ris()`, and `export_bib()`, so the caller must
+  supply an explicit path. The internal `write_refs()` fallback in
+  `R/import_export_helpers.R` now writes to `tempdir()` instead of `getwd()`.
+  All examples write to `tempfile()` / `tempdir()`.
+
+Since the previous review, the package version was incremented from 0.2.0 to
+0.2.1 and a few features were added (incremental deduplication via
+`dedup_citations_add_sources()`, deferred manual review via
+`export_dedup_candidates()` / `reimport_dedup_candidates()`, and a
+deduplication provenance log via `dedup_log()`). These are documented in
+`NEWS.md`. All newly exported functions include `\value` documentation and
+write only to user-supplied paths.
 
 ## Test environments
 
 * Local: Windows 11, R 4.5.0
-* win-builder: R-release and R-devel
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes (local, `R CMD check --as-cran`).
 
-* checking CRAN incoming feasibility ... NOTE
-  Maintainer: 'Trevor Riley <tnriley@gmail.com>'
-
-  The "New submission" wording appears only because the previous version is not
-  yet published on CRAN. Any flagged URLs (e.g. the GNU GPL license pages) are
-  valid and resolve in a browser; the check machine reported transient
-  connection resets.
+On CRAN's incoming checks we expect the standard "New submission" NOTE, since
+the package is not yet published. Any URLs flagged (e.g. the GNU GPL license
+pages) are valid and resolve in a browser.
 
 ## Reverse dependencies
 
-None - CiteSource has no downstream dependents on CRAN.
+None — this is a new submission with no downstream dependents.
 
 ## Notes
 
-R/asys_dedup.R contains code vendored from the ASySD package
+`R/asys_dedup.R` contains code vendored from the ASySD package
 (GPL >= 3, CAMARADES Group / Kaitlyn Hair) with attribution in the file
 header. CiteSource is also GPL >= 3, so the licenses are compatible.

--- a/man/plot_source_overlap_upset.Rd
+++ b/man/plot_source_overlap_upset.Rd
@@ -44,6 +44,7 @@ will be the specific intersections listed.}
     \item{\code{main.bar.color}}{Color of the main bar plot}
     \item{\code{mainbar.y.max}}{The maximum y value of the intersection size bar plot scale. May be useful when aligning multiple UpSet plots horizontally.}
     \item{\code{sets.bar.color}}{Color of set size bar plot}
+    \item{\code{plot.title}}{Title of UpSetR plot}
     \item{\code{point.size}}{Size of points in matrix plot}
     \item{\code{line.size}}{Width of lines in matrix plot}
     \item{\code{mb.ratio}}{Ratio between matrix plot and main bar plot (Keep in terms of hundredths)}
@@ -53,6 +54,7 @@ will be the specific intersections listed.}
     \item{\code{decreasing}}{How the variables in order.by should be ordered. "freq" is decreasing (greatest to least) and "degree" is increasing (least to greatest)}
     \item{\code{show.numbers}}{Show numbers of intersection sizes above bars}
     \item{\code{number.angles}}{The angle of the numbers atop the intersection size bars}
+    \item{\code{number.colors}}{The colors of the numbers atop the intersection size bars}
     \item{\code{group.by}}{How the data should be grouped ("degree" or "sets")}
     \item{\code{cutoff}}{The number of intersections from each set (to cut off at) when aggregating by sets}
     \item{\code{queries}}{Unified query of intersections, elements, and custom row functions. Entered as a list that contains a list of

--- a/man/plot_source_overlap_upset.Rd
+++ b/man/plot_source_overlap_upset.Rd
@@ -44,7 +44,6 @@ will be the specific intersections listed.}
     \item{\code{main.bar.color}}{Color of the main bar plot}
     \item{\code{mainbar.y.max}}{The maximum y value of the intersection size bar plot scale. May be useful when aligning multiple UpSet plots horizontally.}
     \item{\code{sets.bar.color}}{Color of set size bar plot}
-    \item{\code{plot.title}}{Title of UpSetR plot}
     \item{\code{point.size}}{Size of points in matrix plot}
     \item{\code{line.size}}{Width of lines in matrix plot}
     \item{\code{mb.ratio}}{Ratio between matrix plot and main bar plot (Keep in terms of hundredths)}
@@ -54,7 +53,6 @@ will be the specific intersections listed.}
     \item{\code{decreasing}}{How the variables in order.by should be ordered. "freq" is decreasing (greatest to least) and "degree" is increasing (least to greatest)}
     \item{\code{show.numbers}}{Show numbers of intersection sizes above bars}
     \item{\code{number.angles}}{The angle of the numbers atop the intersection size bars}
-    \item{\code{number.colors}}{The colors of the numbers atop the intersection size bars}
     \item{\code{group.by}}{How the data should be grouped ("degree" or "sets")}
     \item{\code{cutoff}}{The number of intersections from each set (to cut off at) when aggregating by sets}
     \item{\code{queries}}{Unified query of intersections, elements, and custom row functions. Entered as a list that contains a list of


### PR DESCRIPTION
## Summary

Brings `enhanced-dedup` into `dev` for the **CRAN 0.2.1 resubmission**. This bundles the 0.2.1 feature work and the fixes for all CRAN reviewer comments on 0.2.0.

### CRAN reviewer comments (0.2.0 was rejected/held — never published) — all addressed
- **Title/Description formatting:** Description no longer starts with "Tools for" (now leads with an active verb, "Deduplicates…"); Title already fixed; software names (`'shiny'`, `'RIS'`, `'CSV'`) single-quoted.
- **Missing `\value` tags:** added to all 5 flagged `.Rd` files (and every new 0.2.1 export).
- **No home-filespace writes:** default `filename` removed from `export_*()`; internal `write_refs()` fallback writes to `tempdir()`.

### New in 0.2.1
- Incremental deduplication: `dedup_citations_add_sources()`.
- Deferred manual review: `export_dedup_candidates()` / `reimport_dedup_candidates()` + `manual_dedup_complete` flag in `export_csv()`.
- Deduplication provenance log: `dedup_log()`.
- `reimport_csv()` reads all columns as character (re-dedup-safe).
- Shiny app: re-import a deduped set, add sources, content-routed multi-file re-import, source overview.
- Dropped unused `networkD3` from Suggests.

### Checks
`R CMD check --as-cran` (local, Windows, R 4.5.0): **0 errors | 0 warnings | 0 notes**. Submitted to win-builder R-devel.

After merge, CRAN submission will be run from `dev`.